### PR TITLE
Wire frasermolyneux-copilot MCP server (pinned to v0.1.0)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -6,6 +6,12 @@
 >
 > **Cloud agents (GitHub Copilot coding agent etc.):** read [`AGENTS.md`](../AGENTS.md) at the repo root first — it is the canonical brief that survives outside the local VS Code multi-root workspace.
 
+## Org conventions via MCP (when available)
+
+If a `frasermolyneux-copilot` MCP server is configured in your client (`.vscode/mcp.json`, the GitHub Copilot coding-agent MCP config at `.github/copilot/mcp_config.json`, or an equivalent stdio MCP wire-up), **prefer its tools** over your own assumptions when answering questions about org standards, branching, workflows, Terraform, .NET projects, Azure patterns, or shared library / platform consumption contracts. The tool surface is `list_instructions`, `get_instruction`, `search_instructions`, plus the matching `_prompts` and `_agents` equivalents (seven tools total). The catalog source-of-truth lives in `frasermolyneux/.github-copilot` — see `mcp-server/README.md` there for the tool contract.
+
+This is **complementary** to the file-load model: if `./.github-copilot/` is checked out in the runner (per `copilot-setup-steps.yml`), continue to read those files directly. If both are available, prefer MCP for freshness. If no MCP server is configured in your client, treat this section as a no-op and fall back to the file paths above.
+
 ## Project Overview
 
 This repository contains **portal-sync**, an Azure Functions (v4, isolated worker) application that synchronizes XtremeIdiots portal data with external game telemetry, forum, and platform services. It runs scheduled and on-demand sync pipelines for ban files, map images, map redirects, and user profile forum data.

--- a/.github/copilot/mcp_config.json
+++ b/.github/copilot/mcp_config.json
@@ -1,0 +1,13 @@
+{
+  "mcpServers": {
+    "frasermolyneux-copilot": {
+      "type": "local",
+      "command": "node",
+      "args": [".github-copilot/mcp-server/dist/index.js"],
+      "env": {
+        "GH_COPILOT_CONTENT_ROOT": ".github-copilot"
+      },
+      "tools": ["*"]
+    }
+  }
+}

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -34,7 +34,17 @@ jobs:
         uses: actions/checkout@v6
         with:
           repository: frasermolyneux/.github-copilot
+          ref: refs/tags/v0.1.0
           path: .github-copilot
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 20.x
+
+      - name: Build MCP server
+        working-directory: .github-copilot/mcp-server
+        run: npm ci && npm run build
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v5

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,12 @@ This file is the brief for the **GitHub Copilot coding agent** (and any other ag
 
 ---
 
+## Org conventions via MCP (when available)
+
+If a `frasermolyneux-copilot` MCP server is configured in your client (`.vscode/mcp.json`, the GitHub Copilot coding-agent MCP config at `.github/copilot/mcp_config.json`, or an equivalent stdio MCP wire-up), **prefer its tools** over your own assumptions when answering questions about org standards, branching, workflows, Terraform, .NET projects, Azure patterns, or shared library / platform consumption contracts. The tool surface is `list_instructions`, `get_instruction`, `search_instructions`, plus the matching `_prompts` and `_agents` equivalents (seven tools total). The catalog source-of-truth lives in `frasermolyneux/.github-copilot` — see `mcp-server/README.md` there for the tool contract.
+
+This is **complementary** to the file-load model: if `./.github-copilot/` is checked out in the runner (per `copilot-setup-steps.yml`), continue to read those files directly. If both are available, prefer MCP for freshness. If no MCP server is configured in your client, treat this section as a no-op and fall back to the file paths above.
+
 ## Required reading (read these BEFORE doing any work)
 
 The `copilot-setup-steps.yml` workflow checks out `frasermolyneux/.github-copilot` at `./.github-copilot/` in the runner, so the paths below resolve.

--- a/README.md
+++ b/README.md
@@ -21,3 +21,7 @@ Please read the [contributing](CONTRIBUTING.md) guidance; this is a learning and
 
 ## Security
 Please read the [security](SECURITY.md) guidance; I am always open to security feedback through email or opening an issue.
+
+## Local dev: MCP wire-up
+
+This repo wires the `frasermolyneux-copilot` MCP server into the GitHub Copilot coding-agent runner via [`.github/copilot/mcp_config.json`](.github/copilot/mcp_config.json), with the server source pinned to tag `v0.1.0` in [`.github/workflows/copilot-setup-steps.yml`](.github/workflows/copilot-setup-steps.yml). For the tool surface, content-root resolution, and wire-up snippets for other clients (VS Code, Claude Desktop, etc.), see [`.github-copilot/mcp-server/README.md`](https://github.com/frasermolyneux/.github-copilot/blob/v0.1.0/mcp-server/README.md).


### PR DESCRIPTION
## Summary

Wires the `frasermolyneux-copilot` MCP server into this repo so the GitHub Copilot coding agent (and any other MCP-capable client) can call the org instructions/prompts/agents catalog directly instead of relying solely on the file-load model. Matches the template already merged into `portal-core` and pins the catalog source to tag `v0.1.0` on `frasermolyneux/.github-copilot`.

## Changes

Five files, all additive (no existing behaviour changed):

- `.github/workflows/copilot-setup-steps.yml` — add `ref: refs/tags/v0.1.0` to the existing `frasermolyneux/.github-copilot` checkout; add `actions/setup-node@v6` (node 20.x) and a `Build MCP server` step (`npm ci && npm run build` in `.github-copilot/mcp-server`) before the existing `Setup .NET` step. Permissions and the .NET step are untouched.
- `.github/copilot/mcp_config.json` — new file declaring the `frasermolyneux-copilot` local stdio MCP server for the coding-agent runner.
- `.github/copilot-instructions.md` and `AGENTS.md` — insert the canonical `## Org conventions via MCP (when available)` bootstrap snippet (sourced via MCP `get_instruction metadata.copilot-instructions`). Snippet is byte-identical across both files (sha256 prefix `DDAC8AA449794730`, 1096 bytes, CRLF, no trailing newline).
- `README.md` — append a brief `## Local dev: MCP wire-up` section pointing to `.github-copilot/mcp-server/README.md` for full docs.

## Validation

- `mcp_config.json` parses as JSON; `copilot-setup-steps.yml` parses as YAML (`yaml.safe_load`).
- Snippet sha256 verified equal across `.github/copilot-instructions.md` and `AGENTS.md`.
- All five files scanned for stray control bytes — zero found. (Initial draft had a bug where a PowerShell double-quoted here-string interpreted `` `f `` and `` `v `` in the README copy as form-feed / vertical-tab; caught by the `code-review` sub-agent and fixed by switching to a single-quoted here-string.)
- `code-review` sub-agent re-run after the fix: no significant findings.

## Risk and rollout

Low blast radius. The MCP wire-up only activates inside MCP-capable clients; the snippet is explicitly worded as a no-op when no server is configured. The `copilot-setup-steps.yml` change adds two new steps before the unchanged .NET step, so the existing `dotnet` toolchain setup is unaffected. No secrets, no contract changes, no consumer impact. Rollback = revert the commit.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>