### PR TITLE
Fix destroy workflows for externally managed APIM APIs

### DIFF
--- a/.github/workflows/destroy-development.yml
+++ b/.github/workflows/destroy-development.yml
@@ -50,10 +50,20 @@ jobs:
           APIM_NAME=$(terraform output -raw api_management_name 2>/dev/null) || true
           APIM_RG=$(terraform output -raw api_management_resource_group_name 2>/dev/null) || true
 
+          delete_api_if_present() {
+            local api_id="$1"
+            if az apim api show --resource-group "$APIM_RG" --service-name "$APIM_NAME" --api-id "$api_id" --only-show-errors >/dev/null 2>&1; then
+              echo "Deleting APIM API $api_id..."
+              az apim api delete --resource-group "$APIM_RG" --service-name "$APIM_NAME" --api-id "$api_id" --delete-revisions true -y --only-show-errors
+            else
+              echo "APIM API $api_id not found, skipping"
+            fi
+          }
+
           if [ -n "$APIM_NAME" ] && [ -n "$APIM_RG" ]; then
             echo "Deleting APIM APIs from $APIM_NAME in $APIM_RG..."
-            az apim api delete --resource-group "$APIM_RG" --service-name "$APIM_NAME" --api-id sync-api-v1 --delete-revisions true -y 2>/dev/null || true
-            az apim api delete --resource-group "$APIM_RG" --service-name "$APIM_NAME" --api-id sync-api-v1-1 --delete-revisions true -y 2>/dev/null || true
+            delete_api_if_present "sync-api-v1"
+            delete_api_if_present "sync-api-v1-1"
           else
             echo "Could not determine APIM details from Terraform outputs, skipping API cleanup"
           fi

--- a/.github/workflows/destroy-development.yml
+++ b/.github/workflows/destroy-development.yml
@@ -35,7 +35,7 @@ jobs:
         shell: bash
         run: |
           cd terraform
-          terraform init -backend-config=backends/dev.backend.hcl -var-file=tfvars/dev.tfvars
+          terraform init -backend-config=backends/dev.backend.hcl
         env:
           ARM_CLIENT_ID: ${{ vars.AZURE_CLIENT_ID }}
           ARM_SUBSCRIPTION_ID: ${{ vars.AZURE_SUBSCRIPTION_ID }}
@@ -54,7 +54,7 @@ jobs:
             local api_id="$1"
             if az apim api show --resource-group "$APIM_RG" --service-name "$APIM_NAME" --api-id "$api_id" --only-show-errors >/dev/null 2>&1; then
               echo "Deleting APIM API $api_id..."
-              az apim api delete --resource-group "$APIM_RG" --service-name "$APIM_NAME" --api-id "$api_id" --delete-revisions true -y --only-show-errors
+              az apim api delete --resource-group "$APIM_RG" --service-name "$APIM_NAME" --api-id "$api_id" --delete-revisions -y --only-show-errors
             else
               echo "APIM API $api_id not found, skipping"
             fi

--- a/.github/workflows/destroy-development.yml
+++ b/.github/workflows/destroy-development.yml
@@ -19,6 +19,51 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - name: Azure Login
+        uses: azure/login@v3
+        with:
+          client-id: ${{ vars.AZURE_CLIENT_ID }}
+          tenant-id: ${{ vars.AZURE_TENANT_ID }}
+          subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v4
+        with:
+          terraform_wrapper: false
+
+      - name: Terraform Init
+        shell: bash
+        run: |
+          cd terraform
+          terraform init -backend-config=backends/dev.backend.hcl -var-file=tfvars/dev.tfvars
+        env:
+          ARM_CLIENT_ID: ${{ vars.AZURE_CLIENT_ID }}
+          ARM_SUBSCRIPTION_ID: ${{ vars.AZURE_SUBSCRIPTION_ID }}
+          ARM_TENANT_ID: ${{ vars.AZURE_TENANT_ID }}
+          ARM_USE_AZUREAD: true
+          ARM_USE_OIDC: true
+
+      - name: Delete externally managed APIM APIs
+        shell: bash
+        run: |
+          cd terraform
+          APIM_NAME=$(terraform output -raw api_management_name 2>/dev/null) || true
+          APIM_RG=$(terraform output -raw api_management_resource_group_name 2>/dev/null) || true
+
+          if [ -n "$APIM_NAME" ] && [ -n "$APIM_RG" ]; then
+            echo "Deleting APIM APIs from $APIM_NAME in $APIM_RG..."
+            az apim api delete --resource-group "$APIM_RG" --service-name "$APIM_NAME" --api-id sync-api-v1 --delete-revisions true -y 2>/dev/null || true
+            az apim api delete --resource-group "$APIM_RG" --service-name "$APIM_NAME" --api-id sync-api-v1-1 --delete-revisions true -y 2>/dev/null || true
+          else
+            echo "Could not determine APIM details from Terraform outputs, skipping API cleanup"
+          fi
+        env:
+          ARM_CLIENT_ID: ${{ vars.AZURE_CLIENT_ID }}
+          ARM_SUBSCRIPTION_ID: ${{ vars.AZURE_SUBSCRIPTION_ID }}
+          ARM_TENANT_ID: ${{ vars.AZURE_TENANT_ID }}
+          ARM_USE_AZUREAD: true
+          ARM_USE_OIDC: true
+
       - uses: frasermolyneux/actions/terraform-destroy@terraform-destroy/v1.2
         with:
           terraform-folder: "terraform"
@@ -27,3 +72,4 @@ jobs:
           AZURE_CLIENT_ID: ${{ vars.AZURE_CLIENT_ID }}
           AZURE_TENANT_ID: ${{ vars.AZURE_TENANT_ID }}
           AZURE_SUBSCRIPTION_ID: ${{ vars.AZURE_SUBSCRIPTION_ID }}
+          perform-checkout: "false"

--- a/.github/workflows/destroy-environment.yml
+++ b/.github/workflows/destroy-environment.yml
@@ -58,10 +58,20 @@ jobs:
           APIM_NAME=$(terraform output -raw api_management_name 2>/dev/null) || true
           APIM_RG=$(terraform output -raw api_management_resource_group_name 2>/dev/null) || true
 
+          delete_api_if_present() {
+            local api_id="$1"
+            if az apim api show --resource-group "$APIM_RG" --service-name "$APIM_NAME" --api-id "$api_id" --only-show-errors >/dev/null 2>&1; then
+              echo "Deleting APIM API $api_id..."
+              az apim api delete --resource-group "$APIM_RG" --service-name "$APIM_NAME" --api-id "$api_id" --delete-revisions true -y --only-show-errors
+            else
+              echo "APIM API $api_id not found, skipping"
+            fi
+          }
+
           if [ -n "$APIM_NAME" ] && [ -n "$APIM_RG" ]; then
             echo "Deleting APIM APIs from $APIM_NAME in $APIM_RG..."
-            az apim api delete --resource-group "$APIM_RG" --service-name "$APIM_NAME" --api-id sync-api-v1 --delete-revisions true -y 2>/dev/null || true
-            az apim api delete --resource-group "$APIM_RG" --service-name "$APIM_NAME" --api-id sync-api-v1-1 --delete-revisions true -y 2>/dev/null || true
+            delete_api_if_present "sync-api-v1"
+            delete_api_if_present "sync-api-v1-1"
           else
             echo "Could not determine APIM details from Terraform outputs, skipping API cleanup"
           fi

--- a/.github/workflows/destroy-environment.yml
+++ b/.github/workflows/destroy-environment.yml
@@ -43,7 +43,7 @@ jobs:
         shell: bash
         run: |
           cd terraform
-          terraform init -backend-config=${{ inputs.environment == 'prd' && 'backends/prd.backend.hcl' || 'backends/dev.backend.hcl' }} -var-file=${{ inputs.environment == 'prd' && 'tfvars/prd.tfvars' || 'tfvars/dev.tfvars' }}
+          terraform init -backend-config=${{ inputs.environment == 'prd' && 'backends/prd.backend.hcl' || 'backends/dev.backend.hcl' }}
         env:
           ARM_CLIENT_ID: ${{ vars.AZURE_CLIENT_ID }}
           ARM_SUBSCRIPTION_ID: ${{ vars.AZURE_SUBSCRIPTION_ID }}
@@ -62,7 +62,7 @@ jobs:
             local api_id="$1"
             if az apim api show --resource-group "$APIM_RG" --service-name "$APIM_NAME" --api-id "$api_id" --only-show-errors >/dev/null 2>&1; then
               echo "Deleting APIM API $api_id..."
-              az apim api delete --resource-group "$APIM_RG" --service-name "$APIM_NAME" --api-id "$api_id" --delete-revisions true -y --only-show-errors
+              az apim api delete --resource-group "$APIM_RG" --service-name "$APIM_NAME" --api-id "$api_id" --delete-revisions -y --only-show-errors
             else
               echo "APIM API $api_id not found, skipping"
             fi

--- a/.github/workflows/destroy-environment.yml
+++ b/.github/workflows/destroy-environment.yml
@@ -25,6 +25,53 @@ jobs:
       group: ${{ github.repository }}-${{ inputs.environment }}
 
     steps:
+      - uses: actions/checkout@v6
+
+      - name: Azure Login
+        uses: azure/login@v3
+        with:
+          client-id: ${{ vars.AZURE_CLIENT_ID }}
+          tenant-id: ${{ vars.AZURE_TENANT_ID }}
+          subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v4
+        with:
+          terraform_wrapper: false
+
+      - name: Terraform Init
+        shell: bash
+        run: |
+          cd terraform
+          terraform init -backend-config=${{ inputs.environment == 'prd' && 'backends/prd.backend.hcl' || 'backends/dev.backend.hcl' }} -var-file=${{ inputs.environment == 'prd' && 'tfvars/prd.tfvars' || 'tfvars/dev.tfvars' }}
+        env:
+          ARM_CLIENT_ID: ${{ vars.AZURE_CLIENT_ID }}
+          ARM_SUBSCRIPTION_ID: ${{ vars.AZURE_SUBSCRIPTION_ID }}
+          ARM_TENANT_ID: ${{ vars.AZURE_TENANT_ID }}
+          ARM_USE_AZUREAD: true
+          ARM_USE_OIDC: true
+
+      - name: Delete externally managed APIM APIs
+        shell: bash
+        run: |
+          cd terraform
+          APIM_NAME=$(terraform output -raw api_management_name 2>/dev/null) || true
+          APIM_RG=$(terraform output -raw api_management_resource_group_name 2>/dev/null) || true
+
+          if [ -n "$APIM_NAME" ] && [ -n "$APIM_RG" ]; then
+            echo "Deleting APIM APIs from $APIM_NAME in $APIM_RG..."
+            az apim api delete --resource-group "$APIM_RG" --service-name "$APIM_NAME" --api-id sync-api-v1 --delete-revisions true -y 2>/dev/null || true
+            az apim api delete --resource-group "$APIM_RG" --service-name "$APIM_NAME" --api-id sync-api-v1-1 --delete-revisions true -y 2>/dev/null || true
+          else
+            echo "Could not determine APIM details from Terraform outputs, skipping API cleanup"
+          fi
+        env:
+          ARM_CLIENT_ID: ${{ vars.AZURE_CLIENT_ID }}
+          ARM_SUBSCRIPTION_ID: ${{ vars.AZURE_SUBSCRIPTION_ID }}
+          ARM_TENANT_ID: ${{ vars.AZURE_TENANT_ID }}
+          ARM_USE_AZUREAD: true
+          ARM_USE_OIDC: true
+
       - uses: frasermolyneux/actions/terraform-destroy@terraform-destroy/v1.2
         with:
           terraform-folder: "terraform"
@@ -33,3 +80,4 @@ jobs:
           AZURE_CLIENT_ID: ${{ vars.AZURE_CLIENT_ID }}
           AZURE_TENANT_ID: ${{ vars.AZURE_TENANT_ID }}
           AZURE_SUBSCRIPTION_ID: ${{ vars.AZURE_SUBSCRIPTION_ID }}
+          perform-checkout: "false"


### PR DESCRIPTION
## Summary

Align destroy workflows with the portal-* org pattern so Terraform can destroy APIM version-set resources even when API instances were imported outside Terraform. This addresses the nightly destroy failure caused by `VersionSet cannot be deleted since it has existing APIs`.

Closes #

## Type of change

- [x] bugfix
- [ ] feature
- [x] chore / refactor
- [ ] docs
- [ ] infra (Terraform)
- [x] ci (GitHub Actions / Dependabot)
- [ ] dependencies
- [ ] breaking change

## Required reading consulted

- [x] `AGENTS.md` (repo brief)
- [x] `.github/copilot-instructions.md` (repo orientation)
- [x] `.github-copilot/.github/instructions/personal.working-preferences.instructions.md` (always-on rules)
- [x] Stack-specific instruction files referenced in `AGENTS.md` (`standards.*`, `patterns.*`, `platform.*`, `shared.*`)

## Validation evidence

### Build

```text
dotnet build src/XtremeIdiots.Portal.Sync.App.sln
Build succeeded.
    0 Warning(s)
    0 Error(s)
```

### Tests

```text
dotnet test src --filter "FullyQualifiedName!~IntegrationTests"
Passed!  - Failed:     0, Passed:    77, Skipped:     0, Total:    77
```

### Format check

```text
terraform -chdir=terraform fmt -check -recursive
(no output = pass)

Note: dotnet format --verify-no-changes currently reports existing whitespace issues in
src/XtremeIdiots.Portal.Sync.App/Redirect/MapRedirectRepository.cs, which are unrelated
to this workflow-only change.
```

### Other (lint, terraform plan summary, screenshots)

N/A

## Risk and rollout

- **Blast radius:** Destroy workflows only (`destroy-development.yml`, `destroy-environment.yml`) for dev/prd manual or scheduled destroy runs.
- **Auto-deploys on merge?** No application deployment impact; affects only future destroy workflow executions.
- **Manual steps post-merge:** None.
- **Rollback plan:** Revert this PR to restore prior workflow behavior.

## Reviewer focus areas

Please focus on the APIM cleanup sequence before `terraform-destroy`: checkout/login/init, resolving APIM outputs from state, and conditional deletion behavior (`sync-api-v1`, `sync-api-v1-1`) that skips missing APIs but surfaces real delete failures.

## Agent attestation

- [x] Ran `code-review` sub-agent; High/Medium findings resolved or justified above in **Reviewer focus areas**
- [ ] PR body cites each acceptance criterion from the linked issue
- [x] No client secrets, GUIDs, connection strings, or hard-coded subscription IDs introduced (`standards.oidc-and-secrets.instructions.md`)