### PR TITLE
feat(caching): adopt Repository 4.2.21 consumer caching with GetMaps override

### DIFF
--- a/src/XtremeIdiots.Portal.Forums.Integration/XtremeIdiots.Portal.Forums.Integration.csproj
+++ b/src/XtremeIdiots.Portal.Forums.Integration/XtremeIdiots.Portal.Forums.Integration.csproj
@@ -12,9 +12,9 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.10" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.10" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.10" />
-    <PackageReference Include="MX.Api.Abstractions" Version="2.3.75" />
+    <PackageReference Include="MX.Api.Abstractions" Version="2.3.76" />
     <PackageReference Include="MX.InvisionCommunity.Api.Abstractions" Version="1.0.61" />
-    <PackageReference Include="XtremeIdiots.Portal.Repository.Abstractions.V1" Version="4.2.16" />
+    <PackageReference Include="XtremeIdiots.Portal.Repository.Abstractions.V1" Version="4.2.21" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/XtremeIdiots.Portal.Sync.App.Tests/RepositoryApiCacheConfigurationTests.cs
+++ b/src/XtremeIdiots.Portal.Sync.App.Tests/RepositoryApiCacheConfigurationTests.cs
@@ -1,12 +1,9 @@
 using System.Linq;
-using System.Threading.Tasks;
 
-using MX.Api.Abstractions;
 using MX.Api.Client.Configuration;
 using MX.Caching.Abstractions;
 
 using XtremeIdiots.Portal.Repository.Abstractions.Interfaces.V1;
-using XtremeIdiots.Portal.Repository.Abstractions.Models.V1.Maps;
 using XtremeIdiots.Portal.Sync.App.Extensions;
 
 namespace XtremeIdiots.Portal.Sync.App.Tests;

--- a/src/XtremeIdiots.Portal.Sync.App.Tests/RepositoryApiCacheConfigurationTests.cs
+++ b/src/XtremeIdiots.Portal.Sync.App.Tests/RepositoryApiCacheConfigurationTests.cs
@@ -1,0 +1,77 @@
+using System.Linq;
+using System.Threading.Tasks;
+
+using MX.Api.Abstractions;
+using MX.Api.Client.Configuration;
+using MX.Caching.Abstractions;
+
+using XtremeIdiots.Portal.Repository.Abstractions.Interfaces.V1;
+using XtremeIdiots.Portal.Repository.Abstractions.Models.V1.Maps;
+using XtremeIdiots.Portal.Sync.App.Extensions;
+
+namespace XtremeIdiots.Portal.Sync.App.Tests;
+
+public class RepositoryApiCacheConfigurationTests
+{
+    [Fact]
+    public void ConfigureCachePolicies_EnablesLibraryDefaults()
+    {
+        var options = BuildOptions();
+
+        Assert.True(options.UseLibraryCacheDefaults);
+    }
+
+    [Fact]
+    public void ConfigureCachePolicies_DisablesGetMapsList_ToProtectReadAfterWriteFlows()
+    {
+        var options = BuildOptions();
+
+        var getMapsMethod = typeof(IMapsApi)
+            .GetMethods()
+            .Single(m => m.Name == nameof(IMapsApi.GetMaps));
+
+        Assert.True(
+            options.CachePolicyOperations.TryGetValue(getMapsMethod, out var operation),
+            "Expected an explicit consumer cache policy for IMapsApi.GetMaps.");
+        Assert.Equal(CachePolicyOperationKind.Disable, operation!.Kind);
+    }
+
+    [Fact]
+    public void ConfigureCachePolicies_LeavesGetMapById_UnderLibraryDefaults()
+    {
+        var options = BuildOptions();
+
+        var getMapByIdMethod = typeof(IMapsApi)
+            .GetMethods()
+            .Single(m => m.Name == nameof(IMapsApi.GetMap)
+                && m.GetParameters().Length == 2
+                && m.GetParameters()[0].ParameterType == typeof(Guid));
+
+        Assert.False(
+            options.CachePolicyOperations.ContainsKey(getMapByIdMethod),
+            "Read-only GetMap(Guid) should retain the library default 10-minute L1 policy.");
+    }
+
+    [Fact]
+    public void ConfigureCachePolicies_LeavesGetGameServers_UnderLibraryDefaults()
+    {
+        var options = BuildOptions();
+
+        var getGameServersMethod = typeof(IGameServersApi)
+            .GetMethods()
+            .Single(m => m.Name == nameof(IGameServersApi.GetGameServers));
+
+        Assert.False(
+            options.CachePolicyOperations.ContainsKey(getGameServersMethod),
+            "GetGameServers is a read-only call in portal-sync and should retain the 60-second L1 default.");
+    }
+
+    private static ApiClientOptions BuildOptions()
+    {
+        var builder = new ApiClientOptionsBuilder();
+        builder.WithBaseUrl("https://example.invalid");
+        builder.WithCachePartition("portal-sync-tests");
+        builder.WithCaching(RepositoryApiCacheConfiguration.ConfigureCachePolicies);
+        return builder.Build();
+    }
+}

--- a/src/XtremeIdiots.Portal.Sync.App/Extensions/RepositoryApiCacheConfiguration.cs
+++ b/src/XtremeIdiots.Portal.Sync.App/Extensions/RepositoryApiCacheConfiguration.cs
@@ -36,14 +36,14 @@ internal static class RepositoryApiCacheConfiguration
 
         Expression<Func<IMapsApi, Task<ApiResult<CollectionModel<MapDto>>>>> getMapsListExpression =
             api => api.GetMaps(
-                null,
-                null,
-                null,
-                null,
-                0,
-                0,
-                null,
-                default);
+                null, // gameType
+                null, // mapNames
+                null, // filter
+                null, // filterString
+                0,    // skipEntries
+                0,    // takeEntries
+                null, // order
+                default); // cancellationToken
 
         cache.NotCached(getMapsListExpression);
     }

--- a/src/XtremeIdiots.Portal.Sync.App/Extensions/RepositoryApiCacheConfiguration.cs
+++ b/src/XtremeIdiots.Portal.Sync.App/Extensions/RepositoryApiCacheConfiguration.cs
@@ -1,0 +1,50 @@
+using System.Linq.Expressions;
+
+using MX.Api.Abstractions;
+using MX.Api.Client.Configuration;
+
+using XtremeIdiots.Portal.Repository.Abstractions.Interfaces.V1;
+using XtremeIdiots.Portal.Repository.Abstractions.Models.V1.Maps;
+
+namespace XtremeIdiots.Portal.Sync.App.Extensions;
+
+/// <summary>
+/// Configures the Repository API client cache policies for portal-sync.
+/// </summary>
+/// <remarks>
+/// <para>
+/// portal-sync executes read-then-mutate flows against <see cref="IMapsApi.GetMaps"/> (map image
+/// backfill and map-redirect reconciliation write to the same maps whose "empty image" state was
+/// just observed). Consumer-side L1 policies are not evicted by the Repository server-side tag
+/// invalidation, so we explicitly force the broad map-list read to bypass client-side caching to
+/// guarantee freshness inside a single job invocation.
+/// </para>
+/// <para>
+/// Single-map reads through <see cref="IMapsApi.GetMap(Guid, CancellationToken)"/>
+/// (used from <c>MapRotationActivities.ResolveMapNames</c> and shared-map discovery) are read-only
+/// within their activity and safely retain the library default 10-minute in-process TTL.
+/// Game-server reads retain the library default 60-second TTL.
+/// </para>
+/// </remarks>
+internal static class RepositoryApiCacheConfiguration
+{
+    public static void ConfigureCachePolicies(CacheBuilder cache)
+    {
+        ArgumentNullException.ThrowIfNull(cache);
+
+        cache.UseLibraryDefaults();
+
+        Expression<Func<IMapsApi, Task<ApiResult<CollectionModel<MapDto>>>>> getMapsListExpression =
+            api => api.GetMaps(
+                null,
+                null,
+                null,
+                null,
+                0,
+                0,
+                null,
+                default);
+
+        cache.NotCached(getMapsListExpression);
+    }
+}

--- a/src/XtremeIdiots.Portal.Sync.App/Program.cs
+++ b/src/XtremeIdiots.Portal.Sync.App/Program.cs
@@ -89,7 +89,10 @@ var host = new HostBuilder()
 
         services.AddRepositoryApiClient(options => options
             .WithBaseUrl(configuration["RepositoryApi:BaseUrl"] ?? throw new InvalidOperationException("RepositoryApi:BaseUrl configuration is required"))
-            .WithEntraIdAuthentication(configuration["RepositoryApi:ApplicationAudience"] ?? throw new InvalidOperationException("RepositoryApi:ApplicationAudience configuration is required")));
+            .WithEntraIdAuthentication(configuration["RepositoryApi:ApplicationAudience"] ?? throw new InvalidOperationException("RepositoryApi:ApplicationAudience configuration is required"))
+            .WithCaching(true)
+            .WithCachePartition("portal-sync")
+            .WithCaching(RepositoryApiCacheConfiguration.ConfigureCachePolicies));
 
         services.AddServersApiClient(options =>
         {

--- a/src/XtremeIdiots.Portal.Sync.App/XtremeIdiots.Portal.Sync.App.csproj
+++ b/src/XtremeIdiots.Portal.Sync.App/XtremeIdiots.Portal.Sync.App.csproj
@@ -25,15 +25,18 @@
 	  <PackageReference Include="Microsoft.Azure.AppConfiguration.Functions.Worker" Version="8.6.0" />
 	  <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="10.0.10" />
 	  <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="10.0.10" />
-    <PackageReference Include="MX.Api.Abstractions" Version="2.3.75" />
-    <PackageReference Include="MX.Api.Client" Version="2.3.75" />
+    <PackageReference Include="MX.Api.Abstractions" Version="2.3.76" />
+    <PackageReference Include="MX.Api.Client" Version="2.3.76" />
 	  <PackageReference Include="MX.InvisionCommunity.Api.Client" Version="1.0.61" />
     <PackageReference Include="MX.Observability.ApplicationInsights.WorkerService" Version="1.1.28" />
-    <PackageReference Include="XtremeIdiots.Portal.Repository.Api.Client.V1" Version="4.2.16" />
-    <PackageReference Include="XtremeIdiots.Portal.Repository.Abstractions.V1" Version="4.2.16" />
+    <PackageReference Include="XtremeIdiots.Portal.Repository.Api.Client.V1" Version="4.2.21" />
+    <PackageReference Include="XtremeIdiots.Portal.Repository.Abstractions.V1" Version="4.2.21" />
     <PackageReference Include="Microsoft.Identity.Web" Version="4.14.2" />
     <PackageReference Include="XtremeIdiots.Portal.Integrations.Servers.Api.Client.V1" Version="4.1.9" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.DurableTask" Version="1.18.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <InternalsVisibleTo Include="XtremeIdiots.Portal.Sync.App.Tests" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\XtremeIdiots.Portal.Forums.Integration\XtremeIdiots.Portal.Forums.Integration.csproj" />


### PR DESCRIPTION
## Summary

Adopt the MX.Api.Client 2.3.76 fluent caching APIs on the Repository API client (bumped to 4.2.21) with correctness-first policies for portal-sync's read-then-mutate map workflows.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Dependency update

## What changed

- Bumped `XtremeIdiots.Portal.Repository.Api.Client.V1` and `XtremeIdiots.Portal.Repository.Abstractions.V1` from `4.2.16` → `4.2.21` across `XtremeIdiots.Portal.Sync.App` and `XtremeIdiots.Portal.Forums.Integration`.
- Bumped `MX.Api.Abstractions` / `MX.Api.Client` from `2.3.75` → `2.3.76` in the same projects.
- Enabled caching on the Repository client in `Program.cs`:
  - `WithCaching(true)` + `WithCachePartition("portal-sync")` (partition is required by `ApiClientOptionsBase.Validate` when caching is on).
  - `UseLibraryDefaults()` — 60 s L1 for game-server single/list, 10 min L1 for single-map reads by id and by (gameType,name), NotCached for user profile / info / health / mutations.
  - Explicit `NotCached` override for the broad `IMapsApi.GetMaps(...)` list.
- New helper `RepositoryApiCacheConfiguration` (internal to the sync app) isolates the cache policy in one place.
- New xUnit tests assert: library defaults are enabled, `GetMaps` list is disabled, and `GetMap(Guid)` / `GetGameServers` are left under the library defaults.

## Why the `GetMaps` list is `NotCached`

`MapImageSync` and `MapRedirectSync` execute read-then-mutate flows against the same maps within a single job invocation:

- `MapImageSync` → `Maps.V1.GetMaps(..., EmptyMapImage, ...)` → `Maps.V1.UpdateMapImage(...)`
- `MapRedirectSync` → `Maps.V1.GetMaps(...)` → `Maps.V1.CreateMaps` / `UpdateMaps`

Consumer-side L1 is **not** evicted by the Repository server-side tag invalidation, so the broad list read must bypass client-side caching to guarantee freshness. Single-map `GetMap(Guid)` (used from `MapRotationActivities.ResolveMapNames` / `GetSharedMapNames`) is read-only within an activity and safely retains the 10 min library default. `GetGameServers` (read-only in `RedirectToGameServerMapSync`) retains the 60 s library default.

## Final cache policy matrix

| Repository API method | Effective policy | Rationale |
|---|---|---|
| `IGameServersApi.GetGameServer(Guid)` | Library default: 60 s L1 | Read-only |
| `IGameServersApi.GetGameServers(...)` | Library default: 60 s L1 | Read-only in `RedirectToGameServerMapSync` |
| `IMapsApi.GetMap(Guid, ct)` | Library default: 10 min L1 | Read-only in `MapRotationActivities` |
| `IMapsApi.GetMap(GameType, string)` | Library default: 10 min L1 | Safe; not called directly |
| **`IMapsApi.GetMaps(...)` (list)** | **Consumer override: NotCached** | Protects MapImageSync + MapRedirectSync read-then-mutate flows |
| `IUserProfileApi.*` | Library default: NotCached | Authorization/claim freshness |
| `IApiInfoApi` / `IApiHealthApi` | Library default: NotCached | Enforced by library |
| All mutations | Library default: NotCached | Enforced by library |
| Config / Dashboard / LiveStatus | Library defaults (deferred) | Out of scope per rollout brief |

## Preserved invariants

- `IJobTelemetry.ExecuteAsync()` wrappers unchanged.
- Paired timer/manual triggers unchanged.
- `ConfigureAwait(false)` unchanged on all touched call paths.
- Forum-sync `AdditionalPermission` claim preservation in `UserProfileForumsSync` unchanged.

## Validation evidence

```
> dotnet build src/XtremeIdiots.Portal.Sync.App.sln
Build succeeded.
    0 Warning(s)
    0 Error(s)

> dotnet test src --filter "FullyQualifiedName!~IntegrationTests" --no-build
Passed!  - Failed:     0, Passed:    94, Skipped:     0, Total:    94, Duration: 135 ms - XtremeIdiots.Portal.Sync.App.Tests.dll (net9.0)

> dotnet format src/XtremeIdiots.Portal.Sync.App.sln --verify-no-changes
(clean; exit 0)
```

`code-review` sub-agent run on the diff — no significant issues.

## Risk and rollout

- **Blast radius:** portal-sync only. No infrastructure or workflow changes; no schema changes; no new secrets.
- **Auto-deploy?** Yes (via existing CI/CD when merged to `main`).
- **Post-merge steps:** none. `CachePartition="portal-sync"` is a stable literal.
- **Rollback:** revert the merge commit; no data migration is involved.
- **Runtime uncertainty:** whether `RepositoryApiClientOptions.CachePolicyOperations` propagates through to each internally-registered typed sub-API client is the library's contract. As defense-in-depth, existing map jobs paginate with increasing `skip`, so cache keys don't collide within a single run even if the override were somehow not applied; the 10 min TTL is also much shorter than the job cadence. Recommend a light smoke check on next scheduled MapImageSync run.

## Agent attestation

- [x] Followed AGENTS.md required reading and stack guardrails
- [x] Build succeeds cleanly
- [x] Tests pass
- [x] `dotnet format --verify-no-changes` clean
- [x] Every scheduled job still wrapped in `IJobTelemetry.ExecuteAsync()`
- [x] Every timer trigger still has a paired HTTP trigger
- [x] Forum-sync `AdditionalPermission` preservation is unchanged
- [x] No new secrets / connection strings
- [x] `code-review` sub-agent run; no High/Medium findings

## Consumer impact

None — no published contract (Abstractions / Client NuGet / Service Bus DTO / Terraform output) changed. This is a consumer-side dependency + configuration change.
