### PR TITLE
feat(caching): re-enable Repository client L1 on 4.2.22 (maps excluded) + host-boot regression test

### DIFF
--- a/src/XtremeIdiots.Portal.Forums.Integration/XtremeIdiots.Portal.Forums.Integration.csproj
+++ b/src/XtremeIdiots.Portal.Forums.Integration/XtremeIdiots.Portal.Forums.Integration.csproj
@@ -12,9 +12,9 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.10" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.10" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.10" />
-    <PackageReference Include="MX.Api.Abstractions" Version="2.3.76" />
+    <PackageReference Include="MX.Api.Abstractions" Version="2.3.77" />
     <PackageReference Include="MX.InvisionCommunity.Api.Abstractions" Version="1.0.61" />
-    <PackageReference Include="XtremeIdiots.Portal.Repository.Abstractions.V1" Version="4.2.21" />
+    <PackageReference Include="XtremeIdiots.Portal.Repository.Abstractions.V1" Version="4.2.22" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/XtremeIdiots.Portal.Sync.App.Tests/RepositoryApiClientRegistrationTests.cs
+++ b/src/XtremeIdiots.Portal.Sync.App.Tests/RepositoryApiClientRegistrationTests.cs
@@ -4,6 +4,7 @@ using MX.Api.Client.Extensions;
 
 using XtremeIdiots.Portal.Repository.Abstractions.Interfaces.V1;
 using XtremeIdiots.Portal.Repository.Api.Client.V1;
+using XtremeIdiots.Portal.Sync.App.Extensions;
 
 namespace XtremeIdiots.Portal.Sync.App.Tests;
 
@@ -19,10 +20,15 @@ namespace XtremeIdiots.Portal.Sync.App.Tests;
 /// XtremeIdiots.Portal.Repository.Abstractions.Interfaces.V1.IAdminActionsApi or one of its
 /// inherited interfaces." The Functions worker exited before host startup.
 ///
-/// These tests mirror the exact production registration shape (BaseUrl + Entra ID only, no
-/// consumer-side caching) and resolve <see cref="IRepositoryApiClient"/> plus representative
-/// typed sub-clients from a fully built <see cref="ServiceProvider"/>. Reintroducing a broken
-/// <c>WithCaching</c> expression will cause these tests to fail before merge.
+/// PR #833 hotfixed by removing all consumer caching. Repository client 4.2.22 + MX.Api.Client
+/// 2.3.77 fix the root cause by scoping every cache-policy expression to its matching typed
+/// sub-API via <c>SharedCacheConfiguration</c>. These tests mirror the exact production
+/// registration shape from <c>Program.cs</c> — including the re-enabled
+/// <see cref="RepositoryApiCacheConfiguration"/> cache-policy chain — and resolve
+/// <see cref="IRepositoryApiClient"/> plus every typed sub-client portal-sync consumes from a
+/// fully built <see cref="ServiceProvider"/>. Any future regression that reintroduces a
+/// cross-sub-API expression, or otherwise breaks the DI options callback, will fail these tests
+/// before merge.
 /// </summary>
 public class RepositoryApiClientRegistrationTests
 {
@@ -53,6 +59,9 @@ public class RepositoryApiClientRegistrationTests
     [InlineData(typeof(IGameServersApi))]
     [InlineData(typeof(IUserProfileApi))]
     [InlineData(typeof(IBanFileMonitorsApi))]
+    [InlineData(typeof(IMapRotationsApi))]
+    [InlineData(typeof(ICentralBanFileStatusApi))]
+    [InlineData(typeof(IDataMaintenanceApi))]
     public void AddRepositoryApiClient_ProductionShape_ResolvesTypedSubClient(Type subClientType)
     {
         using var provider = BuildProductionServiceProvider();
@@ -69,10 +78,15 @@ public class RepositoryApiClientRegistrationTests
         services.AddLogging();
 
         // Mirror the production registration shape from Program.cs exactly: BaseUrl + Entra ID
-        // authentication only. Do not add consumer-side caching here — see class-level remarks.
+        // authentication + the re-enabled consumer cache-policy chain from
+        // RepositoryApiCacheConfiguration. See class-level remarks for why the full production
+        // shape (including caching) is under test here.
         services.AddRepositoryApiClient(options => options
             .WithBaseUrl("https://repository.invalid")
-            .WithEntraIdAuthentication("api://repository.invalid"));
+            .WithEntraIdAuthentication("api://repository.invalid")
+            .WithCaching(true)
+            .WithCachePartition("portal-sync")
+            .WithCaching(RepositoryApiCacheConfiguration.ConfigureCachePolicies));
 
         return services.BuildServiceProvider(validateScopes: true);
     }

--- a/src/XtremeIdiots.Portal.Sync.App.Tests/RepositoryApiClientRegistrationTests.cs
+++ b/src/XtremeIdiots.Portal.Sync.App.Tests/RepositoryApiClientRegistrationTests.cs
@@ -22,13 +22,15 @@ namespace XtremeIdiots.Portal.Sync.App.Tests;
 ///
 /// PR #833 hotfixed by removing all consumer caching. Repository client 4.2.22 + MX.Api.Client
 /// 2.3.77 fix the root cause by scoping every cache-policy expression to its matching typed
-/// sub-API via <c>SharedCacheConfiguration</c>. These tests mirror the exact production
-/// registration shape from <c>Program.cs</c> — including the re-enabled
+/// sub-API via <c>SharedCacheConfiguration</c>. These tests mirror the Repository API client
+/// registration chain from <c>Program.cs</c> exactly — including the re-enabled
 /// <see cref="RepositoryApiCacheConfiguration"/> cache-policy chain — and resolve
 /// <see cref="IRepositoryApiClient"/> plus every typed sub-client portal-sync consumes from a
-/// fully built <see cref="ServiceProvider"/>. Any future regression that reintroduces a
-/// cross-sub-API expression, or otherwise breaks the DI options callback, will fail these tests
-/// before merge.
+/// fully built <see cref="ServiceProvider"/>. Unrelated host wiring (Functions host builder,
+/// App Configuration, Application Insights, other API clients) is intentionally out of scope:
+/// the guarded failure mode is entirely inside <c>AddRepositoryApiClient</c>'s per-sub-client
+/// options callback. Any future regression that reintroduces a cross-sub-API expression, or
+/// otherwise breaks that DI options callback, will fail these tests before merge.
 /// </summary>
 public class RepositoryApiClientRegistrationTests
 {
@@ -77,10 +79,11 @@ public class RepositoryApiClientRegistrationTests
         var services = new ServiceCollection();
         services.AddLogging();
 
-        // Mirror the production registration shape from Program.cs exactly: BaseUrl + Entra ID
-        // authentication + the re-enabled consumer cache-policy chain from
-        // RepositoryApiCacheConfiguration. See class-level remarks for why the full production
-        // shape (including caching) is under test here.
+        // Mirror the Repository API client registration chain from Program.cs exactly: BaseUrl
+        // + Entra ID authentication + the re-enabled consumer cache-policy chain from
+        // RepositoryApiCacheConfiguration. The surrounding host wiring (App Configuration,
+        // Application Insights, other API clients, etc.) is intentionally out of scope — see
+        // class-level remarks for why.
         services.AddRepositoryApiClient(options => options
             .WithBaseUrl("https://repository.invalid")
             .WithEntraIdAuthentication("api://repository.invalid")

--- a/src/XtremeIdiots.Portal.Sync.App/Extensions/RepositoryApiCacheConfiguration.cs
+++ b/src/XtremeIdiots.Portal.Sync.App/Extensions/RepositoryApiCacheConfiguration.cs
@@ -1,0 +1,94 @@
+using System.Linq.Expressions;
+
+using MX.Api.Abstractions;
+using MX.Api.Client.Configuration;
+
+using XtremeIdiots.Portal.Repository.Abstractions.Interfaces.V1;
+using XtremeIdiots.Portal.Repository.Abstractions.Models.V1.Maps;
+
+namespace XtremeIdiots.Portal.Sync.App.Extensions;
+
+/// <summary>
+/// Configures the Repository API client consumer-side L1 cache policies for portal-sync.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Rolled forward on Repository client <c>4.2.22</c> / <c>MX.Api.Client 2.3.77</c>, which uses
+/// <see cref="SharedCacheConfiguration"/> under the covers to scope every expression to its
+/// matching typed sub-API. That fixes the fan-out <c>ArgumentException</c> that took portal-sync
+/// down during PR #832 rollout (hotfixed in PR #833 by removing all consumer caching).
+/// </para>
+/// <para>
+/// <b>Maps are explicitly excluded from client L1 caching.</b> portal-sync executes
+/// read-then-mutate flows against <see cref="IMapsApi"/> within a single job invocation
+/// (<c>MapImageSync</c> reads <c>GetMaps(..., MapsFilter.EmptyMapImage, ...)</c> then writes via
+/// <see cref="IMapsApi.UpdateMapImage"/>; <c>MapRedirectSync</c> reads <c>GetMaps</c> then writes
+/// via <see cref="IMapsApi.CreateMaps"/> / <see cref="IMapsApi.UpdateMaps"/>). Consumer L1 is not
+/// evicted by the Repository server-side tag invalidation, so client-side caching of any map
+/// surface would produce stale read-after-write bugs. <see cref="IMapsApi.GetMap"/> is also
+/// excluded to keep the exclusion uniform: even paths that today only read (e.g.
+/// <c>MapRotationActivities</c>) share the same in-process cache, so caching there would leak
+/// staleness into the same invocation as the mutating jobs.
+/// </para>
+/// <para>
+/// The following surfaces stay under <c>UseLibraryDefaults()</c> because portal-sync never
+/// mutates them:
+/// <list type="bullet">
+///   <item><description><see cref="IGameServersApi"/> — only <c>GetGameServers</c> is called
+///   (from <c>RedirectToGameServerMapSync</c>); portal-sync performs no game-server writes.
+///   Library default is a 60-second in-memory TTL.</description></item>
+/// </list>
+/// All other sub-APIs used by portal-sync (<see cref="IUserProfileApi"/>,
+/// <see cref="IMapRotationsApi"/>, <see cref="ICentralBanFileStatusApi"/>,
+/// <see cref="IDataMaintenanceApi"/>) either have library defaults that ship as NotCached
+/// (user-profile) or ship with no client-side defaults at all — those continue to hit the API
+/// directly and rely on Repository server-side caching, which is the correct behaviour for
+/// read-then-write flows in a single invocation.
+/// </para>
+/// <para>
+/// <see cref="IAdminActionsApi.GetAdminActions"/> is also read-only from portal-sync
+/// (BanFilesRepository regeneration), but the client package ships no library default for it and
+/// active-bans data changes on external timelines, so we keep it uncached and rely on server-side
+/// caching to keep freshness guarantees inside a single ban-file regeneration cycle.
+/// </para>
+/// </remarks>
+internal static class RepositoryApiCacheConfiguration
+{
+    public static void ConfigureCachePolicies(CacheBuilder cache)
+    {
+        ArgumentNullException.ThrowIfNull(cache);
+
+        // Enable the vendor-shipped defaults (60s L1 for GameServer reads, NotCached for
+        // user-profile / api-info / api-health, and a 10-minute L1 for single-map reads which
+        // we override below).
+        cache.UseLibraryDefaults();
+
+        // Force the broad map-list read to bypass client-side caching. Portal-sync's
+        // MapImageSync and MapRedirectSync do read-then-mutate against this list inside a
+        // single invocation, and L1 is not evicted by server-side tag invalidation.
+        // Positional arguments are annotated with inline parameter-name comments because
+        // expression trees disallow named arguments (CS0853).
+        Expression<Func<IMapsApi, Task<ApiResult<CollectionModel<MapDto>>>>> getMapsListExpression =
+            api => api.GetMaps(
+                null, // gameType
+                null, // mapNames
+                null, // filter
+                null, // filterString
+                0,    // skipEntries
+                0,    // takeEntries
+                null, // order
+                default); // cancellationToken
+
+        cache.NotCached(getMapsListExpression);
+
+        // Force single-map reads to bypass client-side caching as well. Even the callers that
+        // today only read (MapRotationActivities.ResolveMapNames) share the same in-process
+        // cache as the mutating map jobs; caching here would surface stale read-after-write.
+        Expression<Func<IMapsApi, Task<ApiResult<MapDto>>>> getMapExpression =
+            api => api.GetMap(
+                Guid.Empty,
+                default);
+
+        cache.NotCached(getMapExpression);
+    }
+}

--- a/src/XtremeIdiots.Portal.Sync.App/Program.cs
+++ b/src/XtremeIdiots.Portal.Sync.App/Program.cs
@@ -89,7 +89,10 @@ var host = new HostBuilder()
 
         services.AddRepositoryApiClient(options => options
             .WithBaseUrl(configuration["RepositoryApi:BaseUrl"] ?? throw new InvalidOperationException("RepositoryApi:BaseUrl configuration is required"))
-            .WithEntraIdAuthentication(configuration["RepositoryApi:ApplicationAudience"] ?? throw new InvalidOperationException("RepositoryApi:ApplicationAudience configuration is required")));
+            .WithEntraIdAuthentication(configuration["RepositoryApi:ApplicationAudience"] ?? throw new InvalidOperationException("RepositoryApi:ApplicationAudience configuration is required"))
+            .WithCaching(true)
+            .WithCachePartition("portal-sync")
+            .WithCaching(RepositoryApiCacheConfiguration.ConfigureCachePolicies));
 
         services.AddServersApiClient(options =>
         {

--- a/src/XtremeIdiots.Portal.Sync.App/XtremeIdiots.Portal.Sync.App.csproj
+++ b/src/XtremeIdiots.Portal.Sync.App/XtremeIdiots.Portal.Sync.App.csproj
@@ -25,12 +25,12 @@
 	  <PackageReference Include="Microsoft.Azure.AppConfiguration.Functions.Worker" Version="8.6.0" />
 	  <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="10.0.10" />
 	  <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="10.0.10" />
-    <PackageReference Include="MX.Api.Abstractions" Version="2.3.76" />
-    <PackageReference Include="MX.Api.Client" Version="2.3.76" />
+    <PackageReference Include="MX.Api.Abstractions" Version="2.3.77" />
+    <PackageReference Include="MX.Api.Client" Version="2.3.77" />
 	  <PackageReference Include="MX.InvisionCommunity.Api.Client" Version="1.0.61" />
     <PackageReference Include="MX.Observability.ApplicationInsights.WorkerService" Version="1.1.28" />
-    <PackageReference Include="XtremeIdiots.Portal.Repository.Api.Client.V1" Version="4.2.21" />
-    <PackageReference Include="XtremeIdiots.Portal.Repository.Abstractions.V1" Version="4.2.21" />
+    <PackageReference Include="XtremeIdiots.Portal.Repository.Api.Client.V1" Version="4.2.22" />
+    <PackageReference Include="XtremeIdiots.Portal.Repository.Abstractions.V1" Version="4.2.22" />
     <PackageReference Include="Microsoft.Identity.Web" Version="4.14.2" />
     <PackageReference Include="XtremeIdiots.Portal.Integrations.Servers.Api.Client.V1" Version="4.1.9" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.DurableTask" Version="1.18.0" />


### PR DESCRIPTION
## Summary
Roll portal-sync onto Repository client `4.2.22` / `MX.Api.Client 2.3.77` (which fix the fan-out `ArgumentException` from PR #832 by scoping every cache-policy expression to its matching typed sub-API via `SharedCacheConfiguration`), selectively re-enable consumer L1 caching with maps explicitly excluded, and add a DI host-boot smoke test that mirrors `Program.cs` exactly so any future regression that breaks the Repository client registration fails before merge.

## Type of change
- [x] New feature (non-breaking change which adds functionality)
- [x] Test coverage (adds/updates automated tests)

## Validation evidence
Real command output (all run locally on this branch):

**Build** (`dotnet build src/XtremeIdiots.Portal.Sync.App.sln`):
```
Build succeeded.
    0 Warning(s)
    0 Error(s)

Time Elapsed 00:00:02.75
```

**Tests** (`dotnet test src/XtremeIdiots.Portal.Sync.App.sln --no-build --filter "FullyQualifiedName!~IntegrationTests"`):
```
Passed!  - Failed:     0, Passed:   100, Skipped:     0, Total:   100, Duration: 132 ms - XtremeIdiots.Portal.Sync.App.Tests.dll (net9.0)
```

**Format check** (`dotnet format src/XtremeIdiots.Portal.Sync.App.sln --verify-no-changes`):
```
(exit 0, no output)
```

The regression test lives in [`RepositoryApiClientRegistrationTests`](src/XtremeIdiots.Portal.Sync.App.Tests/RepositoryApiClientRegistrationTests.cs) and now mirrors the full production shape - `WithBaseUrl` + `WithEntraIdAuthentication` + `WithCaching(true)` + `WithCachePartition("portal-sync")` + `WithCaching(RepositoryApiCacheConfiguration.ConfigureCachePolicies)` - resolving `IRepositoryApiClient` plus `IAdminActionsApi` / `IMapsApi` / `IGameServersApi` / `IUserProfileApi` / `IBanFileMonitorsApi` / `IMapRotationsApi` / `ICentralBanFileStatusApi` / `IDataMaintenanceApi`. It fails against the broken PR #832 registration shape and passes here.

## Risk and rollout
- **Blast radius**: portal-sync Function App only. No public contract changes; no infra changes.
- **Auto-deploy?**: Yes on merge to `main` via existing pipeline.
- **Manual steps post-merge**: None.
- **Rollback plan**: Revert commit; portal-sync returns to the PR #833 no-caching state (functional, just gives up client-side L1 for `GetGameServers`).
- **Runtime risk**: Low. Maps are explicitly `NotCached` (both `GetMaps` and `GetMap`) to preserve the read-after-write freshness guarantee that `MapImageSync` and `MapRedirectSync` rely on. All other read-then-write surfaces portal-sync consumes (`IUserProfileApi`, `IMapRotationsApi`, `ICentralBanFileStatusApi`, `IDataMaintenanceApi`, `IAdminActionsApi`) either ship as `NotCached` in the vendor library defaults or receive no client-side default at all, so they continue to hit the API directly and rely on Repository server-side caching. The only surface that actually gets L1 is `IGameServersApi` reads (portal-sync never mutates game servers).

## Agent attestation
- [x] I ran build, tests, and format check and pasted real output above
- [x] I confirmed no secrets, connection strings, or GUIDs were introduced
- [x] I did not modify `version.json`, workflows, or `Directory.*.props`
- [x] I ran the `code-review` sub-agent against the staged diff and there were no High/Medium findings
- [x] Each acceptance criterion from the task is addressed (package bump; selective L1 re-enable with maps excluded; DI host-boot smoke test under default filter)
- [x] `IJobTelemetry.ExecuteAsync()` and paired timer/HTTP triggers are unchanged (no new jobs added)
- [x] Manually-assigned `AdditionalPermission` claim handling in `UserProfileForumsSync` is untouched