### PR TITLE
feat(clients): bump Invision 1.0.63 + Servers 4.1.14, enable Invision L1 caching, add boot regression test

### DIFF
--- a/src/XtremeIdiots.Portal.Forums.Integration/XtremeIdiots.Portal.Forums.Integration.csproj
+++ b/src/XtremeIdiots.Portal.Forums.Integration/XtremeIdiots.Portal.Forums.Integration.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.10" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.10" />
     <PackageReference Include="MX.Api.Abstractions" Version="2.3.77" />
-    <PackageReference Include="MX.InvisionCommunity.Api.Abstractions" Version="1.0.61" />
+    <PackageReference Include="MX.InvisionCommunity.Api.Abstractions" Version="1.0.63" />
     <PackageReference Include="XtremeIdiots.Portal.Repository.Abstractions.V1" Version="4.2.22" />
   </ItemGroup>
 

--- a/src/XtremeIdiots.Portal.Sync.App.Tests/ExternalApiClientRegistrationTests.cs
+++ b/src/XtremeIdiots.Portal.Sync.App.Tests/ExternalApiClientRegistrationTests.cs
@@ -30,15 +30,17 @@ namespace XtremeIdiots.Portal.Sync.App.Tests;
 /// exercised end-to-end. Any future regression in either library's DI options callback — including
 /// a reintroduction of the cross-sub-API expression fan-out — will fail these tests before merge.
 ///
-/// The Invision registration mirrors the caching decision documented in the PR: only
-/// <see cref="ICoreApi.GetMember"/> and <see cref="IDownloadsApi.GetDownloadFile"/> are consumed by
-/// portal-sync (via <c>UserProfileForumsSync</c> and <c>DemoManager</c> respectively), both are
-/// pure reads whose writes land against a different backing store (the Repository API for user
-/// profile updates; no writes at all for downloads), and <see cref="IForumsApi"/> — which handles
-/// the sync write path via <c>PostTopic</c>/<c>UpdateTopic</c> — is uncached by
-/// <c>UseLibraryDefaults()</c>. Turning on library defaults is therefore safe. The Servers client
-/// ships no cache defaults; the bump to <c>4.1.14</c> is purely for version currency and crash
-/// safety.
+/// The Invision registration mirrors the caching decision documented in the PR: the only
+/// <em>cacheable-by-default read</em> methods portal-sync consumes are
+/// <see cref="ICoreApi.GetMember"/> (via <c>UserProfileForumsSync</c>) and
+/// <see cref="IDownloadsApi.GetDownloadFile"/> (via <c>DemoManager</c>) — both are pure reads
+/// whose corresponding writes land against a different backing store (the Repository API for
+/// user profile updates; no writes at all for downloads). The forum-write path used by
+/// <c>AdminActionTopics</c> goes through <see cref="IForumsApi.PostTopic"/> /
+/// <see cref="IForumsApi.UpdateTopic"/>, which are uncached under
+/// <c>UseLibraryDefaults()</c> and so are unaffected. Turning on library defaults is therefore
+/// safe. The Servers client ships no cache defaults; the bump to <c>4.1.14</c> is purely for
+/// version currency and crash safety.
 /// </summary>
 public class ExternalApiClientRegistrationTests
 {

--- a/src/XtremeIdiots.Portal.Sync.App.Tests/ExternalApiClientRegistrationTests.cs
+++ b/src/XtremeIdiots.Portal.Sync.App.Tests/ExternalApiClientRegistrationTests.cs
@@ -46,7 +46,10 @@ public class ExternalApiClientRegistrationTests
     {
         // The PR #832 regression exception was raised inside the options-configuration callback
         // that Add*ApiClient invokes per sub-client. Registration + provider build must not throw.
-        var exception = Record.Exception(BuildInvisionServiceProvider);
+        var exception = Record.Exception(() =>
+        {
+            using var provider = BuildInvisionServiceProvider();
+        });
 
         Assert.Null(exception);
     }
@@ -75,10 +78,14 @@ public class ExternalApiClientRegistrationTests
 
         Assert.NotNull(subClient);
     }
+
     [Fact]
     public void AddServersApiClient_ProductionShape_DoesNotThrowDuringRegistration()
     {
-        var exception = Record.Exception(BuildServersServiceProvider);
+        var exception = Record.Exception(() =>
+        {
+            using var provider = BuildServersServiceProvider();
+        });
 
         Assert.Null(exception);
     }
@@ -117,8 +124,9 @@ public class ExternalApiClientRegistrationTests
         services.AddLogging();
 
         // Mirror Program.cs exactly: BaseUrl + API key authentication + cache partition
-        // + UseLibraryDefaults(). Only GetCoreHello / GetMember / GetDownloadFile are cached by
-        // MX.InvisionCommunity.Api.Client 1.0.63 defaults; IForumsApi is entirely uncached.
+        // + UseLibraryDefaults(). The exact set of methods covered by UseLibraryDefaults() is
+        // owned by the MX.InvisionCommunity.Api.Client package; see the PR body for the decision
+        // rationale on why enabling defaults is safe for portal-sync's read paths.
         services.AddInvisionApiClient(options => options
             .WithBaseUrl("https://forums.invalid")
             .WithApiKeyAuthentication("test-api-key", "key", ApiKeyLocation.QueryParameter)

--- a/src/XtremeIdiots.Portal.Sync.App.Tests/ExternalApiClientRegistrationTests.cs
+++ b/src/XtremeIdiots.Portal.Sync.App.Tests/ExternalApiClientRegistrationTests.cs
@@ -1,0 +1,144 @@
+using Microsoft.Extensions.DependencyInjection;
+
+using MX.Api.Client.Configuration;
+using MX.Api.Client.Extensions;
+
+using MX.InvisionCommunity.Api.Abstractions;
+using MX.InvisionCommunity.Api.Abstractions.Interfaces;
+using MX.InvisionCommunity.Api.Client;
+
+using XtremeIdiots.Portal.Integrations.Servers.Abstractions.Interfaces.V1;
+using XtremeIdiots.Portal.Integrations.Servers.Api.Client.V1;
+
+namespace XtremeIdiots.Portal.Sync.App.Tests;
+
+/// <summary>
+/// Guards the Invision and Servers API client DI registrations used by <c>Program.cs</c> against
+/// the same class of startup-crash regression that took portal-sync down under
+/// <c>Repository.Api.Client.V1 4.2.21</c> (PR #832 → hotfix PR #833 → rolled forward under PR #834
+/// on <c>MX.Api.Client 2.3.77</c>'s <see cref="SharedCacheConfiguration"/>).
+///
+/// The exact failure mode was an <see cref="ArgumentException"/> — "The expression must invoke a
+/// method declared by ... or one of its inherited interfaces" — raised inside the per-sub-client
+/// options callback executed by <c>Add*ApiClient</c> during DI configuration. That crashed the
+/// Functions worker before host startup. This test mirrors the Invision + Servers client
+/// registrations from <c>Program.cs</c> exactly, builds a fully validated <see cref="ServiceProvider"/>,
+/// and resolves every typed sub-client consumed by portal-sync. Any future regression in either
+/// library's DI options callback — including a reintroduction of the cross-sub-API expression
+/// fan-out — will fail these tests before merge.
+///
+/// The Invision registration mirrors the caching decision documented in the PR: only
+/// <see cref="ICoreApi.GetMember"/> and <see cref="IDownloadsApi.GetDownloadFile"/> are consumed by
+/// portal-sync (via <c>UserProfileForumsSync</c> and <c>DemoManager</c> respectively), both are
+/// pure reads whose writes land against a different backing store (the Repository API for user
+/// profile updates; no writes at all for downloads), and <see cref="IForumsApi"/> — which handles
+/// the sync write path via <c>PostTopic</c>/<c>UpdateTopic</c> — is uncached by
+/// <c>UseLibraryDefaults()</c>. Turning on library defaults is therefore safe. The Servers client
+/// ships no cache defaults; the bump to <c>4.1.14</c> is purely for version currency and crash
+/// safety.
+/// </summary>
+public class ExternalApiClientRegistrationTests
+{
+    [Fact]
+    public void AddInvisionApiClient_ProductionShape_DoesNotThrowDuringRegistration()
+    {
+        // The PR #832 regression exception was raised inside the options-configuration callback
+        // that Add*ApiClient invokes per sub-client. Registration + provider build must not throw.
+        var exception = Record.Exception(BuildInvisionServiceProvider);
+
+        Assert.Null(exception);
+    }
+
+    [Fact]
+    public void AddInvisionApiClient_ProductionShape_ResolvesInvisionApiClient()
+    {
+        using var provider = BuildInvisionServiceProvider();
+        using var scope = provider.CreateScope();
+
+        var client = scope.ServiceProvider.GetRequiredService<IInvisionApiClient>();
+
+        Assert.NotNull(client);
+    }
+
+    [Theory]
+    [InlineData(typeof(ICoreApi))]
+    [InlineData(typeof(IDownloadsApi))]
+    [InlineData(typeof(IForumsApi))]
+    public void AddInvisionApiClient_ProductionShape_ResolvesTypedSubClient(Type subClientType)
+    {
+        using var provider = BuildInvisionServiceProvider();
+        using var scope = provider.CreateScope();
+
+        var subClient = scope.ServiceProvider.GetRequiredService(subClientType);
+
+        Assert.NotNull(subClient);
+    }
+
+    [Fact]
+    public void AddServersApiClient_ProductionShape_DoesNotThrowDuringRegistration()
+    {
+        var exception = Record.Exception(BuildServersServiceProvider);
+
+        Assert.Null(exception);
+    }
+
+    [Fact]
+    public void AddServersApiClient_ProductionShape_ResolvesServersApiClient()
+    {
+        using var provider = BuildServersServiceProvider();
+        using var scope = provider.CreateScope();
+
+        var client = scope.ServiceProvider.GetRequiredService<IServersApiClient>();
+
+        Assert.NotNull(client);
+    }
+
+    [Theory]
+    [InlineData(typeof(IMapsApi))]
+    [InlineData(typeof(IConfigApi))]
+    [InlineData(typeof(ICod2RconApi))]
+    [InlineData(typeof(ICod4RconApi))]
+    [InlineData(typeof(ICoD4xRconApi))]
+    [InlineData(typeof(ICod5RconApi))]
+    public void AddServersApiClient_ProductionShape_ResolvesTypedSubClient(Type subClientType)
+    {
+        using var provider = BuildServersServiceProvider();
+        using var scope = provider.CreateScope();
+
+        var subClient = scope.ServiceProvider.GetRequiredService(subClientType);
+
+        Assert.NotNull(subClient);
+    }
+
+    private static ServiceProvider BuildInvisionServiceProvider()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+
+        // Mirror Program.cs exactly: BaseUrl + API key authentication + cache partition
+        // + UseLibraryDefaults(). Only GetCoreHello / GetMember / GetDownloadFile are cached by
+        // MX.InvisionCommunity.Api.Client 1.0.63 defaults; IForumsApi is entirely uncached.
+        services.AddInvisionApiClient(options => options
+            .WithBaseUrl("https://forums.invalid")
+            .WithApiKeyAuthentication("test-api-key", "key", ApiKeyLocation.QueryParameter)
+            .WithCachePartition("portal-sync")
+            .WithCaching(cache => cache.UseLibraryDefaults()));
+
+        return services.BuildServiceProvider(validateScopes: true);
+    }
+
+    private static ServiceProvider BuildServersServiceProvider()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+
+        // Mirror Program.cs exactly: BaseUrl + Entra ID authentication. The Servers client ships
+        // no cache defaults, so no WithCaching() call is made — the bump to 4.1.14 gives us the
+        // crash-safe per-sub-client scoping without changing runtime behaviour.
+        services.AddServersApiClient(options => options
+            .WithBaseUrl("https://servers.invalid")
+            .WithEntraIdAuthentication("api://servers.invalid"));
+
+        return services.BuildServiceProvider(validateScopes: true);
+    }
+}

--- a/src/XtremeIdiots.Portal.Sync.App.Tests/ExternalApiClientRegistrationTests.cs
+++ b/src/XtremeIdiots.Portal.Sync.App.Tests/ExternalApiClientRegistrationTests.cs
@@ -24,10 +24,11 @@ namespace XtremeIdiots.Portal.Sync.App.Tests;
 /// Functions worker before host startup. This test mirrors the Invision + Servers client
 /// registrations from <c>Program.cs</c> exactly, builds a <see cref="ServiceProvider"/> with both
 /// <see cref="ServiceProviderOptions.ValidateOnBuild"/> and <see cref="ServiceProviderOptions.ValidateScopes"/>
-/// enabled (so every registered service is realised at build time and every scoped-from-singleton
-/// mistake surfaces), and resolves every typed sub-client consumed by portal-sync. Any future
-/// regression in either library's DI options callback — including a reintroduction of the
-/// cross-sub-API expression fan-out — will fail these tests before merge.
+/// enabled (so unresolvable registrations fail at provider-build time and scoped-from-singleton
+/// mistakes surface), and additionally resolves the composite client plus every typed sub-client
+/// portal-sync consumes so the DI options callback that raised the PR #832 exception is actually
+/// exercised end-to-end. Any future regression in either library's DI options callback — including
+/// a reintroduction of the cross-sub-API expression fan-out — will fail these tests before merge.
 ///
 /// The Invision registration mirrors the caching decision documented in the PR: only
 /// <see cref="ICoreApi.GetMember"/> and <see cref="IDownloadsApi.GetDownloadFile"/> are consumed by

--- a/src/XtremeIdiots.Portal.Sync.App.Tests/ExternalApiClientRegistrationTests.cs
+++ b/src/XtremeIdiots.Portal.Sync.App.Tests/ExternalApiClientRegistrationTests.cs
@@ -22,10 +22,12 @@ namespace XtremeIdiots.Portal.Sync.App.Tests;
 /// method declared by ... or one of its inherited interfaces" — raised inside the per-sub-client
 /// options callback executed by <c>Add*ApiClient</c> during DI configuration. That crashed the
 /// Functions worker before host startup. This test mirrors the Invision + Servers client
-/// registrations from <c>Program.cs</c> exactly, builds a fully validated <see cref="ServiceProvider"/>,
-/// and resolves every typed sub-client consumed by portal-sync. Any future regression in either
-/// library's DI options callback — including a reintroduction of the cross-sub-API expression
-/// fan-out — will fail these tests before merge.
+/// registrations from <c>Program.cs</c> exactly, builds a <see cref="ServiceProvider"/> with both
+/// <see cref="ServiceProviderOptions.ValidateOnBuild"/> and <see cref="ServiceProviderOptions.ValidateScopes"/>
+/// enabled (so every registered service is realised at build time and every scoped-from-singleton
+/// mistake surfaces), and resolves every typed sub-client consumed by portal-sync. Any future
+/// regression in either library's DI options callback — including a reintroduction of the
+/// cross-sub-API expression fan-out — will fail these tests before merge.
 ///
 /// The Invision registration mirrors the caching decision documented in the PR: only
 /// <see cref="ICoreApi.GetMember"/> and <see cref="IDownloadsApi.GetDownloadFile"/> are consumed by
@@ -73,7 +75,6 @@ public class ExternalApiClientRegistrationTests
 
         Assert.NotNull(subClient);
     }
-
     [Fact]
     public void AddServersApiClient_ProductionShape_DoesNotThrowDuringRegistration()
     {
@@ -124,7 +125,11 @@ public class ExternalApiClientRegistrationTests
             .WithCachePartition("portal-sync")
             .WithCaching(cache => cache.UseLibraryDefaults()));
 
-        return services.BuildServiceProvider(validateScopes: true);
+        return services.BuildServiceProvider(new ServiceProviderOptions
+        {
+            ValidateScopes = true,
+            ValidateOnBuild = true,
+        });
     }
 
     private static ServiceProvider BuildServersServiceProvider()
@@ -139,6 +144,10 @@ public class ExternalApiClientRegistrationTests
             .WithBaseUrl("https://servers.invalid")
             .WithEntraIdAuthentication("api://servers.invalid"));
 
-        return services.BuildServiceProvider(validateScopes: true);
+        return services.BuildServiceProvider(new ServiceProviderOptions
+        {
+            ValidateScopes = true,
+            ValidateOnBuild = true,
+        });
     }
 }

--- a/src/XtremeIdiots.Portal.Sync.App/Program.cs
+++ b/src/XtremeIdiots.Portal.Sync.App/Program.cs
@@ -108,7 +108,9 @@ var host = new HostBuilder()
 
         services.AddInvisionApiClient(options => options
             .WithBaseUrl(configuration["XtremeIdiots:Forums:BaseUrl"] ?? throw new InvalidOperationException("XtremeIdiots:Forums:BaseUrl configuration is required"))
-            .WithApiKeyAuthentication(configuration["XtremeIdiots:Forums:ApiKey"] ?? throw new InvalidOperationException("XtremeIdiots:Forums:ApiKey configuration is required"), "key", MX.Api.Client.Configuration.ApiKeyLocation.QueryParameter));
+            .WithApiKeyAuthentication(configuration["XtremeIdiots:Forums:ApiKey"] ?? throw new InvalidOperationException("XtremeIdiots:Forums:ApiKey configuration is required"), "key", MX.Api.Client.Configuration.ApiKeyLocation.QueryParameter)
+            .WithCachePartition("portal-sync")
+            .WithCaching(cache => cache.UseLibraryDefaults()));
 
         services.AddAdminActionTopics();
 

--- a/src/XtremeIdiots.Portal.Sync.App/XtremeIdiots.Portal.Sync.App.csproj
+++ b/src/XtremeIdiots.Portal.Sync.App/XtremeIdiots.Portal.Sync.App.csproj
@@ -27,12 +27,12 @@
 	  <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="10.0.10" />
     <PackageReference Include="MX.Api.Abstractions" Version="2.3.77" />
     <PackageReference Include="MX.Api.Client" Version="2.3.77" />
-	  <PackageReference Include="MX.InvisionCommunity.Api.Client" Version="1.0.61" />
+	  <PackageReference Include="MX.InvisionCommunity.Api.Client" Version="1.0.63" />
     <PackageReference Include="MX.Observability.ApplicationInsights.WorkerService" Version="1.1.28" />
     <PackageReference Include="XtremeIdiots.Portal.Repository.Api.Client.V1" Version="4.2.22" />
     <PackageReference Include="XtremeIdiots.Portal.Repository.Abstractions.V1" Version="4.2.22" />
     <PackageReference Include="Microsoft.Identity.Web" Version="4.14.2" />
-    <PackageReference Include="XtremeIdiots.Portal.Integrations.Servers.Api.Client.V1" Version="4.1.9" />
+    <PackageReference Include="XtremeIdiots.Portal.Integrations.Servers.Api.Client.V1" Version="4.1.14" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.DurableTask" Version="1.18.0" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
## Summary

Rolls forward the two remaining external-API client packages consumed by portal-sync onto the crash-safe `MX.Api.Client 2.3.77` `SharedCacheConfiguration` line (mirrors the Repository client rollout in #834), enables Invision consumer-side L1 caching, and adds a boot-time regression test that guards against the #832-class startup crash for these clients.

Closes #

## Type of change

- [ ] bugfix
- [x] feature
- [x] chore / refactor
- [ ] docs
- [ ] infra (Terraform)
- [ ] ci (GitHub Actions / Dependabot)
- [x] dependencies
- [ ] breaking change

## Required reading consulted

- [x] `AGENTS.md` (repo brief)
- [x] `.github/copilot-instructions.md` (repo orientation)
- [x] `.github-copilot/.github/instructions/personal.working-preferences.instructions.md` (always-on rules)
- [x] Stack-specific instruction files referenced in `AGENTS.md` (`standards.*`, `patterns.*`, `platform.*`, `shared.*`)

## Validation evidence

### Build

```text
$ dotnet build src/XtremeIdiots.Portal.Sync.App.sln -c Debug --nologo
  XtremeIdiots.Portal.Forums.Integration -> .../XtremeIdiots.Portal.Forums.Integration.dll
  WorkerExtensions -> .../Microsoft.Azure.Functions.Worker.Extensions.dll
  XtremeIdiots.Portal.Sync.App -> .../XtremeIdiots.Portal.Sync.App.dll
  XtremeIdiots.Portal.Sync.App.Tests -> .../XtremeIdiots.Portal.Sync.App.Tests.dll

Build succeeded.
    0 Warning(s)
    0 Error(s)
```

### Tests

```text
$ dotnet test src/XtremeIdiots.Portal.Sync.App.sln --no-build --nologo
Test run for .../XtremeIdiots.Portal.Sync.App.Tests.dll (.NETCoreApp,Version=v9.0)
A total of 1 test files matched the specified pattern.

Passed!  - Failed:     0, Passed:   113, Skipped:     0, Total:   113, Duration: 127 ms
```

### Format check

```text
$ dotnet format src/XtremeIdiots.Portal.Sync.App.sln --verify-no-changes
(no output — pass, exit 0)
```

### Other

`code-review` sub-agent run against the diff. Verdict: **No significant issues found.** Reviewer confirmed:
- `UserProfileForumsSync.GetMember` (30s cache) — write path targets Repository API's `UserProfile`, not the Invision member. No read-after-write hazard.
- `DemoManager.GetDownloadFile` (30s cache) — pure read of static download metadata. Safe.
- `AdminActionTopics.PostTopic` / `UpdateTopic` — on `IForumsApi`, which is uncached under `UseLibraryDefaults()`. Sync write path unaffected.
- The new registration test builds a scope-validated `ServiceProvider` — exactly the shape that would have caught the #832 options-callback fan-out crash at build time.

## Risk and rollout

- **Blast radius:** portal-sync only (dev + prd Functions app). No cross-service contract change, no infra change, no distributed cache; L1 is purely in-process.
- **Auto-deploys on merge?** Yes on merge to `main` via the standard pipeline (per `standards.branching-and-prs`).
- **Manual steps post-merge:** None.
- **Rollback plan:** Revert the merge commit. Package versions and the `WithCaching(...)` call are the only runtime-visible changes; test coverage guarantees registration composes with or without them. If a client-side stale read is ever observed on `GetMember` or `GetDownloadFile`, follow-up patch can drop the `WithCaching(...)` call or add `.NotCached<T,U>(...)` for the affected method — no schema/state migration required.

## Consumer impact

<!-- No published contract changed (no Abstractions / Api.Client / Service Bus DTO / Terraform output). Section intentionally omitted. -->

## Reviewer focus areas

- The Invision cache decision itself (`Program.cs` line ~109): only `GetMember` (30s) and `GetDownloadFile` (30s) from `UseLibraryDefaults()` are actually consumed by portal-sync; `GetCoreHello` is not used at all; `IForumsApi` (the sync write path) is uncached by defaults. No per-method `.NotCached(...)` exclusions were added — confirm the read/write analysis holds.
- `ExternalApiClientRegistrationTests.cs` mirrors `Program.cs`'s Invision + Servers registrations exactly (BaseUrl + auth + cache partition + `UseLibraryDefaults()` for Invision; no `WithCaching` for Servers since that package ships no cache defaults). Confirm the sub-API `[Theory]` inputs cover the surfaces portal-sync actually consumes (I intentionally kept the Servers list to the RCon/Config/Maps surfaces the app touches — did not enumerate `IApiHealthApi`, `IApiInfoApi`, `IFilesApi`, `IFileBrowseApi`, `IQueryApi`, or the Rust/L4D2/Insurgency RCon APIs which are not consumed here).

## Agent attestation

- [x] Ran `code-review` sub-agent; High/Medium findings resolved or justified above in **Reviewer focus areas**
- [x] PR body cites each acceptance criterion from the linked issue
- [x] No client secrets, GUIDs, connection strings, or hard-coded subscription IDs introduced (`standards.oidc-and-secrets.instructions.md`)